### PR TITLE
Check bottom on transcluded content change.

### DIFF
--- a/infinite-scroller-component.js
+++ b/infinite-scroller-component.js
@@ -10,8 +10,8 @@ function register(module) {
     bindings: {
       canScroll: '<brCanScroll',
       // TODO: replace "canScroll" with one of these?, deprecate brCanScroll
-      //pagesRemaining: '<?brPagesRemaining',
-      //hasMore: '<?brHasMorePages',
+      // pagesRemaining: '<?brPagesRemaining',
+      // hasMore: '<?brHasMorePages',
       viewportSelector: '@?brScrollViewport',
       onLoadPage: '&brOnLoadPage'
     },
@@ -29,6 +29,14 @@ function Ctrl($element, $scope, $timeout, $window) {
 
   var viewport;
   var bottom = getBottom($element);
+
+  // FIXME: use MutationObserver on bottom element position instead of $watch
+  // on text in element
+  $scope.$watch(function() {
+    return $element.text().length;
+  }, function() {
+    loadPageAsNeeded();
+  });
 
   // watch for scrollability changes
   $scope.$watch(function() {


### PR DESCRIPTION
This fixes an issue where the scroller properly triggers a second query with an offset when the component is initialized.  However, if the transcluded content changes after another query is submitted, this component was still working with the value of the bottom of the view port at the end of the first iteration.  The first chunk of records from the second query did not exceed the larger viewport size and therefore did not trigger another page load which results in only the first chunk of records being displayed.
